### PR TITLE
remove SyntaxWarning 

### DIFF
--- a/easysurrogate/analysis/GP_analysis.py
+++ b/easysurrogate/analysis/GP_analysis.py
@@ -260,7 +260,7 @@ class GP_analysis(BaseAnalysis):
         # only the first component
         y_test_plot = y_test
         y_train_plot = y_train
-        if y_pred.shape[1] is not 1:
+        if y_pred.shape[1] != 1:
             y_test_plot = y_test[:, [0]]
             y_train_plot = y_train[:, [0]]
             y_pred = y_pred[:, 0]


### PR DESCRIPTION
remove SyntaxWarning (see https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/)
